### PR TITLE
feat: 멤버 Entity 생성, 회원가입 서비스 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.hibernate.orm:hibernate-envers'
+	implementation "org.springframework.boot:spring-boot-starter-mail"
+
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/zerobase/SelfWash/SelfWashApplication.java
+++ b/src/main/java/com/zerobase/SelfWash/SelfWashApplication.java
@@ -2,8 +2,10 @@ package com.zerobase.SelfWash;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SelfWashApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/zerobase/SelfWash/member/application/SignUpApplication.java
+++ b/src/main/java/com/zerobase/SelfWash/member/application/SignUpApplication.java
@@ -1,0 +1,57 @@
+package com.zerobase.SelfWash.member.application;
+
+import com.zerobase.SelfWash.member.components.MailComponent;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.service.AdminSignUpService;
+import com.zerobase.SelfWash.member.service.SignUpService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SignUpApplication {
+
+  private final List<SignUpService> signUpServices;
+  private final AdminSignUpService adminSignUpService;
+  private final MailComponent mailComponent;
+
+  public String signUp(String type, SignUpForm signUpForm) {
+    SignUpService signUpService = getSignUpService(type);
+
+    String key = UUID.randomUUID().toString();
+    signUpForm.setEmailAuthKey(key);
+    signUpService.signUp(signUpForm);
+
+    sendMail(type, signUpForm.getEmail(), key);
+
+    return "회원가입이 완료되었습니다.";
+  }
+
+  public void verifyEmail(String type ,String email, String key) {
+    SignUpService signUpService = getSignUpService(type);
+
+    signUpService.verifyEmail(email, key);
+  }
+
+  public String adminSignUp(AdminSignUpForm adminSignUpForm) {
+    adminSignUpService.signUp(adminSignUpForm);
+
+    return "관리자 계정 가입이 완료되었습니다.";
+  }
+
+  private void sendMail(String type, String email, String key) {
+    String subject = "SelfWash 가입을 축하드립니다.";
+    String text = "<p> SelfWash 가입을 축하드립니다.</p><p>아래 링크를 클릭하셔서 가입을 완료해주세요</p>" +
+        "<div><a target = '_blank' href = 'http://localhost:8080/signup/verify/" + type + "?email=" + email + "&key=" + key + "'> 가입 완료 </a></div>";
+    mailComponent.sendMail(email, subject, text);
+  }
+
+  private SignUpService getSignUpService(String userType) {
+    return signUpServices.stream().filter(signUpService -> signUpService.support(userType))
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("회원가입 유형이 유효한 값이 아닙니다."));
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/application/SignUpApplication.java
+++ b/src/main/java/com/zerobase/SelfWash/member/application/SignUpApplication.java
@@ -3,6 +3,7 @@ package com.zerobase.SelfWash.member.application;
 import com.zerobase.SelfWash.member.components.MailComponent;
 import com.zerobase.SelfWash.member.domain.form.SignUpForm;
 import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
 import com.zerobase.SelfWash.member.service.AdminSignUpService;
 import com.zerobase.SelfWash.member.service.SignUpService;
 import java.util.List;
@@ -18,7 +19,7 @@ public class SignUpApplication {
   private final AdminSignUpService adminSignUpService;
   private final MailComponent mailComponent;
 
-  public String signUp(String type, SignUpForm signUpForm) {
+  public void signUp(MemberType type, SignUpForm signUpForm) {
     SignUpService signUpService = getSignUpService(type);
 
     String key = UUID.randomUUID().toString();
@@ -27,30 +28,27 @@ public class SignUpApplication {
 
     sendMail(type, signUpForm.getEmail(), key);
 
-    return "회원가입이 완료되었습니다.";
   }
 
-  public void verifyEmail(String type ,String email, String key) {
+  public void verifyEmail(MemberType type ,String email, String key) {
     SignUpService signUpService = getSignUpService(type);
 
     signUpService.verifyEmail(email, key);
   }
 
-  public String adminSignUp(AdminSignUpForm adminSignUpForm) {
+  public void adminSignUp(AdminSignUpForm adminSignUpForm) {
     adminSignUpService.signUp(adminSignUpForm);
-
-    return "관리자 계정 가입이 완료되었습니다.";
   }
 
-  private void sendMail(String type, String email, String key) {
+  private void sendMail(MemberType type, String email, String key) {
     String subject = "SelfWash 가입을 축하드립니다.";
     String text = "<p> SelfWash 가입을 축하드립니다.</p><p>아래 링크를 클릭하셔서 가입을 완료해주세요</p>" +
-        "<div><a target = '_blank' href = 'http://localhost:8080/signup/verify/" + type + "?email=" + email + "&key=" + key + "'> 가입 완료 </a></div>";
+        "<div><a target = '_blank' href = 'http://localhost:8080/signup/verify/" + type.toString().toLowerCase() + "?email=" + email + "&key=" + key + "'> 가입 완료 </a></div>";
     mailComponent.sendMail(email, subject, text);
   }
 
-  private SignUpService getSignUpService(String userType) {
-    return signUpServices.stream().filter(signUpService -> signUpService.support(userType))
+  private SignUpService getSignUpService(MemberType type) {
+    return signUpServices.stream().filter(signUpService -> signUpService.support(type))
         .findFirst()
         .orElseThrow(() -> new RuntimeException("회원가입 유형이 유효한 값이 아닙니다."));
   }

--- a/src/main/java/com/zerobase/SelfWash/member/components/MailComponent.java
+++ b/src/main/java/com/zerobase/SelfWash/member/components/MailComponent.java
@@ -1,0 +1,33 @@
+package com.zerobase.SelfWash.member.components;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MailComponent {
+  private final JavaMailSender mailSender;
+
+  public void sendMail(String email, String subject, String text) {
+
+    MimeMessagePreparator message = mimeMessage -> {
+      MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+      messageHelper.setTo(email);
+      messageHelper.setSubject(subject);
+      messageHelper.setText(text, true);
+    };
+
+    try {
+      mailSender.send(message);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/controller/SignUpController.java
+++ b/src/main/java/com/zerobase/SelfWash/member/controller/SignUpController.java
@@ -1,5 +1,8 @@
 package com.zerobase.SelfWash.member.controller;
 
+import static com.zerobase.SelfWash.member.domain.type.MemberType.CUSTOMER;
+import static com.zerobase.SelfWash.member.domain.type.MemberType.OWNER;
+
 import com.zerobase.SelfWash.member.application.SignUpApplication;
 import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
 import com.zerobase.SelfWash.member.domain.form.SignUpForm;
@@ -21,29 +24,32 @@ public class SignUpController {
 
   @PostMapping("/customer")
   public ResponseEntity<String> customerSignUp(@RequestBody SignUpForm signUpForm) {
-    return ResponseEntity.ok(signUpApplication.signUp("customer",signUpForm));
+    signUpApplication.signUp(CUSTOMER,signUpForm);
+    return ResponseEntity.ok("회원가입이 완료되었습니다.");
   }
 
   @GetMapping("/verify/customer")
   public ResponseEntity<String> customerVerify(@RequestParam String email, @RequestParam String key) {
-    signUpApplication.verifyEmail("customer",email, key);
+    signUpApplication.verifyEmail(CUSTOMER,email, key);
     return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
   }
 
   @PostMapping("/owner")
   public ResponseEntity<String> ownerSignUp(@RequestBody SignUpForm signUpForm) {
-    return ResponseEntity.ok(signUpApplication.signUp("owner",signUpForm));
+    signUpApplication.signUp(OWNER,signUpForm);
+    return ResponseEntity.ok("회원가입이 완료되었습니다.");
   }
 
   @GetMapping("/verify/owner")
   public ResponseEntity<String> ownerVerify(@RequestParam String email, @RequestParam String key) {
-    signUpApplication.verifyEmail("owner",email, key);
+    signUpApplication.verifyEmail(OWNER,email, key);
     return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
   }
 
   @PostMapping("/admin")
   public ResponseEntity<String> adminSignUp(@RequestBody AdminSignUpForm signUpForm) {
-    return ResponseEntity.ok(signUpApplication.adminSignUp(signUpForm));
+    signUpApplication.adminSignUp(signUpForm);
+    return ResponseEntity.ok("회원가입이 완료되었습니다.");
   }
 
 

--- a/src/main/java/com/zerobase/SelfWash/member/controller/SignUpController.java
+++ b/src/main/java/com/zerobase/SelfWash/member/controller/SignUpController.java
@@ -1,0 +1,52 @@
+package com.zerobase.SelfWash.member.controller;
+
+import com.zerobase.SelfWash.member.application.SignUpApplication;
+import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/signup")
+@RequiredArgsConstructor
+public class SignUpController {
+
+  private final SignUpApplication signUpApplication;
+
+  @PostMapping("/customer")
+  public ResponseEntity<String> customerSignUp(@RequestBody SignUpForm signUpForm) {
+    return ResponseEntity.ok(signUpApplication.signUp("customer",signUpForm));
+  }
+
+  @GetMapping("/verify/customer")
+  public ResponseEntity<String> customerVerify(@RequestParam String email, @RequestParam String key) {
+    signUpApplication.verifyEmail("customer",email, key);
+    return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
+  }
+
+  @PostMapping("/owner")
+  public ResponseEntity<String> ownerSignUp(@RequestBody SignUpForm signUpForm) {
+    return ResponseEntity.ok(signUpApplication.signUp("owner",signUpForm));
+  }
+
+  @GetMapping("/verify/owner")
+  public ResponseEntity<String> ownerVerify(@RequestParam String email, @RequestParam String key) {
+    signUpApplication.verifyEmail("owner",email, key);
+    return ResponseEntity.ok("이메일 인증이 완료되었습니다.");
+  }
+
+  @PostMapping("/admin")
+  public ResponseEntity<String> adminSignUp(@RequestBody AdminSignUpForm signUpForm) {
+    return ResponseEntity.ok(signUpApplication.adminSignUp(signUpForm));
+  }
+
+
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Admin.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Admin.java
@@ -1,0 +1,42 @@
+package com.zerobase.SelfWash.member.domain.entity;
+
+import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Admin extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String memberId;
+  private String password;
+  private String phone;
+  private String name;
+
+  private boolean adminAuthYn;
+
+  public static Admin signUpFrom(AdminSignUpForm signUpForm) {
+    return Admin.builder()
+        .memberId(signUpForm.getMemberId())
+        //TODO 나중에 BCrypt.hashpw(signUpForm.getPassword(), BCrypt.gensalt()) 로 변경
+        .password(signUpForm.getPassword())
+        .phone(signUpForm.getPhone())
+        .name(signUpForm.getName())
+        .adminAuthYn(false)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/BaseEntity.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.zerobase.SelfWash.member.domain.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@Setter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+  @LastModifiedDate
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Customer extends BaseEntity {
+public class Customer extends BaseEntity  implements Member {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
@@ -1,0 +1,53 @@
+package com.zerobase.SelfWash.member.domain.entity;
+
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Customer extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @Column(unique = true)
+  private String email;
+
+  private String password;
+  private String phone;
+  private String name;
+  private int balance;
+  private String account;
+
+  private String emailAuthKey;
+  private boolean emailAuthYn;
+
+  public static Customer signUpFrom(SignUpForm signUpForm) {
+    return Customer.builder()
+        .email(signUpForm.getEmail())
+        //TODO 나중에 BCrypt.hashpw(signUpForm.getPassword(), BCrypt.gensalt()) 로 변경
+        .password(signUpForm.getPassword())
+        .phone(signUpForm.getPhone())
+        .name(signUpForm.getName())
+        .balance(0)
+        .account(signUpForm.getAccount())
+        .emailAuthKey(signUpForm.getEmailAuthKey())
+        .emailAuthYn(false)
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Member.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Member.java
@@ -1,0 +1,9 @@
+package com.zerobase.SelfWash.member.domain.entity;
+
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+
+public interface Member {
+  boolean isEmailAuthYn();
+  String getEmailAuthKey();
+  void setEmailAuthYn(boolean emailAuthYn);
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
@@ -18,7 +18,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class Owner extends BaseEntity {
+public class Owner extends BaseEntity implements Member{
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
@@ -1,0 +1,50 @@
+package com.zerobase.SelfWash.member.domain.entity;
+
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Owner extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @Column(unique = true)
+  private String email;
+
+  private String password;
+  private String phone;
+  private String name;
+  private String account;
+
+  private String emailAuthKey;
+  private boolean emailAuthYn;
+
+  public static Owner signUpFrom(SignUpForm signUpForm) {
+    return Owner.builder()
+        .email(signUpForm.getEmail())
+        //TODO 나중에 BCrypt.hashpw(signUpForm.getPassword(), BCrypt.gensalt()) 로 변경
+        .password(signUpForm.getPassword())
+        .phone(signUpForm.getPhone())
+        .name(signUpForm.getName())
+        .account(signUpForm.getAccount())
+        .emailAuthKey(signUpForm.getEmailAuthKey())
+        .emailAuthYn(false)
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/form/AdminSignUpForm.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/form/AdminSignUpForm.java
@@ -1,0 +1,19 @@
+package com.zerobase.SelfWash.member.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AdminSignUpForm {
+  private String memberId;
+  private String password;
+  private String phone;
+  private String name;
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/form/SignUpForm.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/form/SignUpForm.java
@@ -1,0 +1,21 @@
+package com.zerobase.SelfWash.member.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpForm {
+  private String email;
+  private String password;
+  private String phone;
+  private String name;
+  private String account;
+  private String emailAuthKey;
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/AdminRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/AdminRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.SelfWash.member.domain.repository;
+
+import com.zerobase.SelfWash.member.domain.entity.Admin;
+import com.zerobase.SelfWash.member.domain.entity.Owner;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+  Optional<Admin> findByMemberId(String memberId);
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/AdminRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/AdminRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, Long> {
   Optional<Admin> findByMemberId(String memberId);
+
+  boolean existsByMemberId(String memberId);
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/CustomerRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/CustomerRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.SelfWash.member.domain.repository;
+
+import com.zerobase.SelfWash.member.domain.entity.Customer;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+  Optional<Customer> findByEmail(String email);
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/CustomerRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/CustomerRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
 
   Optional<Customer> findByEmail(String email);
+
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/OwnerRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/OwnerRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
 
   Optional<Owner> findByEmail(String email);
+
+  boolean existsByEmail(String email);
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/repository/OwnerRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/repository/OwnerRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.SelfWash.member.domain.repository;
+
+import com.zerobase.SelfWash.member.domain.entity.Owner;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OwnerRepository extends JpaRepository<Owner, Long> {
+
+  Optional<Owner> findByEmail(String email);
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/type/MemberType.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/type/MemberType.java
@@ -1,0 +1,5 @@
+package com.zerobase.SelfWash.member.domain.type;
+
+public enum MemberType {
+  CUSTOMER, OWNER, ADMIN
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/AdminSignUpService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/AdminSignUpService.java
@@ -1,0 +1,10 @@
+package com.zerobase.SelfWash.member.service;
+
+import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+
+public interface AdminSignUpService {
+
+  void signUp(AdminSignUpForm form);
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/SignUpService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/SignUpService.java
@@ -1,14 +1,44 @@
 package com.zerobase.SelfWash.member.service;
 
+import com.zerobase.SelfWash.member.domain.entity.Member;
 import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 public interface SignUpService {
 
-  boolean support(String userType);
+  boolean support(MemberType type);
 
   void signUp(SignUpForm form);
 
   void verifyEmail(String email, String key);
+
+
+  default void validateEmail(SignUpForm form
+      , Predicate<String> existsByEmail) {
+    if (existsByEmail.test(form.getEmail())) {
+      throw new RuntimeException("이미 존재하는 이메일 입니다.");
+    }
+  }
+
+  default void verifyEmail(String email
+      , String key
+      , Function<String, Optional<? extends Member>> findByEmail) {
+    
+    Member member = findByEmail.apply(email)
+        .orElseThrow(()-> new RuntimeException("존재하지 않는 이메일입니다."));
+    if (member.isEmailAuthYn()) {
+      throw new RuntimeException("이미 인증받은 이메일입니다.");
+    }
+    if (!member.getEmailAuthKey().equals(key)) {
+      throw new RuntimeException("인증키가 일치하지 않습니다.");
+    }
+    member.setEmailAuthYn(true);
+  }
+
+
 
 
 }

--- a/src/main/java/com/zerobase/SelfWash/member/service/SignUpService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/SignUpService.java
@@ -1,0 +1,14 @@
+package com.zerobase.SelfWash.member.service;
+
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+
+public interface SignUpService {
+
+  boolean support(String userType);
+
+  void signUp(SignUpForm form);
+
+  void verifyEmail(String email, String key);
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/AdminSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/AdminSignUpServiceImpl.java
@@ -1,0 +1,27 @@
+package com.zerobase.SelfWash.member.service.impl;
+
+import com.zerobase.SelfWash.member.domain.entity.Admin;
+import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import com.zerobase.SelfWash.member.domain.repository.AdminRepository;
+import com.zerobase.SelfWash.member.service.AdminSignUpService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminSignUpServiceImpl implements AdminSignUpService {
+  private final AdminRepository adminRepository;
+
+  @Override
+  public void signUp(AdminSignUpForm form) {
+    Optional<Admin> admin = adminRepository.findByMemberId(form.getMemberId());
+    if (admin.isPresent()) {
+      throw new RuntimeException("이미 존재하는 아이디입니다.");
+    }
+
+    adminRepository.save(Admin.signUpFrom(form));
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/AdminSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/AdminSignUpServiceImpl.java
@@ -2,10 +2,8 @@ package com.zerobase.SelfWash.member.service.impl;
 
 import com.zerobase.SelfWash.member.domain.entity.Admin;
 import com.zerobase.SelfWash.member.domain.form.AdminSignUpForm;
-import com.zerobase.SelfWash.member.domain.form.SignUpForm;
 import com.zerobase.SelfWash.member.domain.repository.AdminRepository;
 import com.zerobase.SelfWash.member.service.AdminSignUpService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,8 +14,7 @@ public class AdminSignUpServiceImpl implements AdminSignUpService {
 
   @Override
   public void signUp(AdminSignUpForm form) {
-    Optional<Admin> admin = adminRepository.findByMemberId(form.getMemberId());
-    if (admin.isPresent()) {
+    if (adminRepository.existsByMemberId(form.getMemberId())) {
       throw new RuntimeException("이미 존재하는 아이디입니다.");
     }
 

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/CustomerSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/CustomerSignUpServiceImpl.java
@@ -1,0 +1,53 @@
+package com.zerobase.SelfWash.member.service.impl;
+
+import com.zerobase.SelfWash.member.domain.entity.Customer;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import com.zerobase.SelfWash.member.domain.repository.CustomerRepository;
+import com.zerobase.SelfWash.member.service.SignUpService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerSignUpServiceImpl implements SignUpService {
+
+  private final CustomerRepository customerRepository;
+
+  @Override
+  public boolean support(String userType) {
+    return "customer".equalsIgnoreCase(userType);
+  }
+
+  @Override
+  public void signUp(SignUpForm form) {
+    Optional<Customer> optionalCustomer = customerRepository.findByEmail(form.getEmail());
+    if (optionalCustomer.isPresent()) {
+      throw new RuntimeException("이미 존재하는 이메일입니다.");
+    }
+
+    customerRepository.save(Customer.signUpFrom(form));
+  }
+
+  @Override
+  @Transactional
+  public void verifyEmail(String email, String key) {
+    Optional<Customer> optionalCustomer = customerRepository.findByEmail(email);
+    if (!optionalCustomer.isPresent()) {
+      throw new RuntimeException("존재하지 않는 이메일입니다.");
+    }
+    Customer customer = optionalCustomer.get();
+
+    if (customer.isEmailAuthYn()) {
+      throw new RuntimeException("이미 인증받은 이메일입니다.");
+    }
+    if (!customer.getEmailAuthKey().equals(key)) {
+      throw new RuntimeException("인증키가 일치하지 않습니다.");
+    }
+
+    customer.setEmailAuthYn(true);
+  }
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/CustomerSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/CustomerSignUpServiceImpl.java
@@ -1,10 +1,12 @@
 package com.zerobase.SelfWash.member.service.impl;
 
+import static com.zerobase.SelfWash.member.domain.type.MemberType.CUSTOMER;
+
 import com.zerobase.SelfWash.member.domain.entity.Customer;
 import com.zerobase.SelfWash.member.domain.form.SignUpForm;
 import com.zerobase.SelfWash.member.domain.repository.CustomerRepository;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
 import com.zerobase.SelfWash.member.service.SignUpService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,37 +18,20 @@ public class CustomerSignUpServiceImpl implements SignUpService {
   private final CustomerRepository customerRepository;
 
   @Override
-  public boolean support(String userType) {
-    return "customer".equalsIgnoreCase(userType);
+  public boolean support(MemberType type) {
+    return CUSTOMER == type;
   }
 
   @Override
   public void signUp(SignUpForm form) {
-    Optional<Customer> optionalCustomer = customerRepository.findByEmail(form.getEmail());
-    if (optionalCustomer.isPresent()) {
-      throw new RuntimeException("이미 존재하는 이메일입니다.");
-    }
-
+    validateEmail(form, customerRepository::existsByEmail);
     customerRepository.save(Customer.signUpFrom(form));
   }
 
   @Override
   @Transactional
   public void verifyEmail(String email, String key) {
-    Optional<Customer> optionalCustomer = customerRepository.findByEmail(email);
-    if (!optionalCustomer.isPresent()) {
-      throw new RuntimeException("존재하지 않는 이메일입니다.");
-    }
-    Customer customer = optionalCustomer.get();
-
-    if (customer.isEmailAuthYn()) {
-      throw new RuntimeException("이미 인증받은 이메일입니다.");
-    }
-    if (!customer.getEmailAuthKey().equals(key)) {
-      throw new RuntimeException("인증키가 일치하지 않습니다.");
-    }
-
-    customer.setEmailAuthYn(true);
+    verifyEmail(email, key, customerRepository::findByEmail);
   }
 
 

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/OwnerSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/OwnerSignUpServiceImpl.java
@@ -1,12 +1,15 @@
 package com.zerobase.SelfWash.member.service.impl;
 
+import static com.zerobase.SelfWash.member.domain.type.MemberType.OWNER;
+
 import com.zerobase.SelfWash.member.domain.entity.Owner;
 import com.zerobase.SelfWash.member.domain.form.SignUpForm;
 import com.zerobase.SelfWash.member.domain.repository.OwnerRepository;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
 import com.zerobase.SelfWash.member.service.SignUpService;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,35 +18,19 @@ public class OwnerSignUpServiceImpl implements SignUpService {
   private final OwnerRepository ownerRepository;
 
   @Override
-  public boolean support(String userType) {
-    return "owner".equalsIgnoreCase(userType);
+  public boolean support(MemberType type) {
+    return OWNER == type;
   }
 
   @Override
   public void signUp(SignUpForm form) {
-    Optional<Owner> optionalOwner = ownerRepository.findByEmail(form.getEmail());
-    if (optionalOwner.isPresent()) {
-      throw new RuntimeException("이미 존재하는 이메일입니다.");
-    }
-
+    validateEmail(form, ownerRepository::existsByEmail);
     ownerRepository.save(Owner.signUpFrom(form));
   }
 
   @Override
+  @Transactional
   public void verifyEmail(String email, String key) {
-    Optional<Owner> optionalOwner = ownerRepository.findByEmail(email);
-    if (!optionalOwner.isPresent()) {
-      throw new RuntimeException("존재하지 않는 이메일입니다.");
-    }
-    Owner owner = optionalOwner.get();
-
-    if (owner.isEmailAuthYn()) {
-      throw new RuntimeException("이미 인증받은 이메일입니다.");
-    }
-    if (!owner.getEmailAuthKey().equals(key)) {
-      throw new RuntimeException("인증키가 일치하지 않습니다.");
-    }
-
-    owner.setEmailAuthYn(true);
+    verifyEmail(email, key, ownerRepository::findByEmail);
   }
 }

--- a/src/main/java/com/zerobase/SelfWash/member/service/impl/OwnerSignUpServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/impl/OwnerSignUpServiceImpl.java
@@ -1,0 +1,49 @@
+package com.zerobase.SelfWash.member.service.impl;
+
+import com.zerobase.SelfWash.member.domain.entity.Owner;
+import com.zerobase.SelfWash.member.domain.form.SignUpForm;
+import com.zerobase.SelfWash.member.domain.repository.OwnerRepository;
+import com.zerobase.SelfWash.member.service.SignUpService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerSignUpServiceImpl implements SignUpService {
+
+  private final OwnerRepository ownerRepository;
+
+  @Override
+  public boolean support(String userType) {
+    return "owner".equalsIgnoreCase(userType);
+  }
+
+  @Override
+  public void signUp(SignUpForm form) {
+    Optional<Owner> optionalOwner = ownerRepository.findByEmail(form.getEmail());
+    if (optionalOwner.isPresent()) {
+      throw new RuntimeException("이미 존재하는 이메일입니다.");
+    }
+
+    ownerRepository.save(Owner.signUpFrom(form));
+  }
+
+  @Override
+  public void verifyEmail(String email, String key) {
+    Optional<Owner> optionalOwner = ownerRepository.findByEmail(email);
+    if (!optionalOwner.isPresent()) {
+      throw new RuntimeException("존재하지 않는 이메일입니다.");
+    }
+    Owner owner = optionalOwner.get();
+
+    if (owner.isEmailAuthYn()) {
+      throw new RuntimeException("이미 인증받은 이메일입니다.");
+    }
+    if (!owner.getEmailAuthKey().equals(key)) {
+      throw new RuntimeException("인증키가 일치하지 않습니다.");
+    }
+
+    owner.setEmailAuthYn(true);
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,23 @@
 spring.application.name=SelfWash
 
-spring.datasource.url=jdbc:mysql://localhost:3306
+spring.datasource.url=jdbc:mysql://localhost:3306/self_wash
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.username=root
 spring.datasource.password=zerobase
+
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=create-drop
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=bigzeropark1015@gmail.com
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.protocol=smtp
+
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.default-encoding=UTF-8
+
+spring.data.redis.host=localhost
+spring.data.redis.port=6379
+spring.data.redis.password=zerobase

--- a/src/main/scratch/member.http
+++ b/src/main/scratch/member.http
@@ -1,0 +1,40 @@
+### 고객 회원가입
+POST http://localhost:8080/signup/customer
+Content-Type: application/json
+
+{
+  "email": "pty10510@gmail.com",
+  "password": "1234",
+  "phone": "010-1234-1234",
+  "name": "james",
+  "account": "1234-0000-0000"
+}
+
+### 고객 이메일 인증
+GET http://localhost:8080/signup/verify/customer?email=pty10510@gmail.com&key=f39bcce3-b314-4e61-ae63-3ddfddc5c08a
+
+### 점주 회원가입
+POST http://localhost:8080/signup/owner
+Content-Type: application/json
+
+{
+  "email": "pty10510@gmail.com",
+  "password": "1234",
+  "phone": "010-1234-4567",
+  "name": "mike",
+  "account": "1234-1111-2222"
+}
+
+### 점주 이메일 인증
+GET http://localhost:8080/signup/verify/owner?email=pty10510@gmail.com&key=21326316-cd9f-4702-aac3-e7836e9bd3ea
+
+### 관리자 회원가입
+POST http://localhost:8080/signup/admin
+Content-Type: application/json
+
+{
+  "memberId": "pty10510",
+  "password": "1234",
+  "phone": "010-1111-2222",
+  "name": "tom"
+}

--- a/src/main/scratch/member.http
+++ b/src/main/scratch/member.http
@@ -3,7 +3,7 @@ POST http://localhost:8080/signup/customer
 Content-Type: application/json
 
 {
-  "email": "pty10510@gmail.com",
+  "email": "emfprhs105@naver.com",
   "password": "1234",
   "phone": "010-1234-1234",
   "name": "james",
@@ -11,7 +11,7 @@ Content-Type: application/json
 }
 
 ### 고객 이메일 인증
-GET http://localhost:8080/signup/verify/customer?email=pty10510@gmail.com&key=f39bcce3-b314-4e61-ae63-3ddfddc5c08a
+GET http://localhost:8080/signup/verify/customer?email=emfprhs105@naver.com&key=f39bcce3-b314-4e61-ae63-3ddfddc5c08a
 
 ### 점주 회원가입
 POST http://localhost:8080/signup/owner


### PR DESCRIPTION
…일 인증 기능 추가)

### 변경사항
**AS-IS**
- 프로젝트 초기 상태로 데이터베이스 모델링만 되어 있는 상태

**TO-BE**
- 데이터 베이스 설정
- 멤버유형(Owner, Customer, Admin) 에 따른 Entity생성
- 멤버유형에 따른 회원가입 기능 구현
- Owner, Customer의 경우, 필요정보와 가입 과정이 유사하기 때문에 같은 SignUp인터페이스를 상속받아 기능 구현
- 메일 인증을 위해 MailComponent 생성 (JavaMailSender를 통해 구현)
- Admin의 경우 필요 정보와 가입 과정이 다른 멤버유형과 다소 차이가 있기 때문에 인터페이스 분리 
- 멤버 가입 API 테스트를 위해 scratch 파일 생성

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 