### PR TITLE
feat: 멤버 관리 기능(정보 수정, 삭제) 추가, swagger-ui 구현

### DIFF
--- a/src/main/java/com/zerobase/SelfWash/config/security/SecurityConfiguration.java
+++ b/src/main/java/com/zerobase/SelfWash/config/security/SecurityConfiguration.java
@@ -7,6 +7,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
+@EnableMethodSecurity
 public class SecurityConfiguration {
 
   private final MemberFilter memberFilter;

--- a/src/main/java/com/zerobase/SelfWash/config/security/filter/MemberFilter.java
+++ b/src/main/java/com/zerobase/SelfWash/config/security/filter/MemberFilter.java
@@ -40,6 +40,8 @@ public class MemberFilter extends OncePerRequestFilter {
 
     String token = tokenFromRequest(request);
 
+    log.info("{} : {}", request, token);
+
     if (!jwtProvider.validateToken(token)) {
       log.info("유효하지 않은 토큰 값{}", token);
       throw new ServletException("Invalid token");
@@ -59,8 +61,6 @@ public class MemberFilter extends OncePerRequestFilter {
       throw new RuntimeException("유효한 토큰이 아닙니다.");
     }
 
-    return bearerToken.substring(TOKEN_PREFIX.length());
+    return bearerToken.substring(TOKEN_PREFIX.length()).trim();
   }
-
-
 }

--- a/src/main/java/com/zerobase/SelfWash/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/zerobase/SelfWash/config/swagger/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.zerobase.SelfWash.config.swagger;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI customOpenAPI() {
+    // Security 스키마 정의
+    SecurityScheme securityScheme = new SecurityScheme()
+        .type(SecurityScheme.Type.HTTP)
+        .scheme("bearer")
+        .bearerFormat("JWT");
+
+    // Security 요구사항 추가
+    SecurityRequirement securityRequirement = new SecurityRequirement()
+        .addList("BearerAuth");
+
+    return new OpenAPI()
+        .info(new Info().title("OpenAPI definition").version("1.0"))
+        .addSecurityItem(securityRequirement)
+        .components(new io.swagger.v3.oas.models.Components()
+            .addSecuritySchemes("BearerAuth", securityScheme));
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/application/MemberManageApplication.java
+++ b/src/main/java/com/zerobase/SelfWash/member/application/MemberManageApplication.java
@@ -1,0 +1,43 @@
+package com.zerobase.SelfWash.member.application;
+
+import com.zerobase.SelfWash.member.domain.dto.AdminDto;
+import com.zerobase.SelfWash.member.domain.dto.UserDto;
+import com.zerobase.SelfWash.member.domain.form.AdminUpdateForm;
+import com.zerobase.SelfWash.member.domain.form.UserUpdateForm;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import com.zerobase.SelfWash.member.service.manage.AdminManageService;
+import com.zerobase.SelfWash.member.service.manage.UserManageService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberManageApplication {
+
+  private final List<UserManageService> userManageServices;
+  private final AdminManageService adminManageService;
+
+  public UserDto updateUser (Long id, UserUpdateForm form, MemberType memberType) {
+    return getUserManageService(memberType).updateUser(id, form);
+  }
+
+  public void deleteUser (Long id, MemberType memberType) {
+    getUserManageService(memberType).deleteUser(id);
+  }
+
+  private UserManageService getUserManageService(MemberType memberType) {
+    return userManageServices.stream().filter(userManageService -> userManageService.support(memberType))
+        .findFirst()
+        .orElseThrow(() -> new RuntimeException("로그인 유형이 유효한 값이 아닙니다."));
+  }
+
+  public AdminDto updateAdmin (Long id, AdminUpdateForm form) {
+    return adminManageService.updateAdmin(id, form);
+  }
+
+  public void deleteAdmin (Long id) {
+    adminManageService.deleteAdmin(id);
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/controller/MemberManageController.java
+++ b/src/main/java/com/zerobase/SelfWash/member/controller/MemberManageController.java
@@ -1,0 +1,125 @@
+package com.zerobase.SelfWash.member.controller;
+
+import static com.zerobase.SelfWash.member.domain.type.MemberType.*;
+
+import com.zerobase.SelfWash.config.security.JwtProvider;
+import com.zerobase.SelfWash.member.application.MemberManageApplication;
+import com.zerobase.SelfWash.member.domain.dto.AdminDto;
+import com.zerobase.SelfWash.member.domain.dto.UserDto;
+import com.zerobase.SelfWash.member.domain.form.AdminUpdateForm;
+import com.zerobase.SelfWash.member.domain.form.UserSignUpForm;
+import com.zerobase.SelfWash.member.domain.form.UserUpdateForm;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.pulsar.PulsarProperties.Admin;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/manage")
+@RequiredArgsConstructor
+public class MemberManageController {
+
+  private final MemberManageApplication memberManageApplication;
+  private final JwtProvider jwtProvider;
+
+  @Operation(
+      summary = "고객 회원 정보 수정",
+      tags = {"회원 정보 관리"}
+  )
+  @PutMapping("/customer/update")
+  @PreAuthorize("hasAuthority('CUSTOMER')")
+  public ResponseEntity<UserDto> updateCustomer(
+      @RequestHeader(name = "Authorization") String token,
+      @RequestBody UserUpdateForm signUpForm) {
+
+    return ResponseEntity.ok(memberManageApplication.updateUser(
+        jwtProvider.getMemberId(token),
+        signUpForm,
+        CUSTOMER));
+  }
+
+  @Operation(
+      summary = "고객 회원 삭제",
+      tags = {"회원 정보 관리"}
+  )
+  @DeleteMapping("/customer/delete")
+  @PreAuthorize("hasAuthority('CUSTOMER')")
+  public ResponseEntity<String> deleteCustomer(
+      @RequestHeader(name = "Authorization") String token) {
+
+    memberManageApplication.deleteUser(jwtProvider.getMemberId(token), CUSTOMER);
+
+    return ResponseEntity.ok("회원이 삭제되었습니다.");
+  }
+
+
+  @Operation(
+      summary = "점주 회원 정보 수정",
+      tags = {"회원 정보 관리"}
+  )
+  @PutMapping("/owner/update")
+  @PreAuthorize("hasAuthority('OWNER')")
+  public ResponseEntity<UserDto> updateOwner(
+      @RequestHeader(name = "Authorization") String token,
+      @RequestBody UserUpdateForm signUpForm) {
+
+    return ResponseEntity.ok(memberManageApplication.updateUser(
+        jwtProvider.getMemberId(token),
+        signUpForm,
+        OWNER));
+  }
+
+  @Operation(
+      summary = "점주 회원 삭제",
+      tags = {"회원 정보 관리"}
+  )
+  @DeleteMapping("/owner/delete")
+  @PreAuthorize("hasAuthority('OWNER')")
+  public ResponseEntity<String> deleteOwner(
+      @RequestHeader(name = "Authorization") String token) {
+
+    memberManageApplication.deleteUser(jwtProvider.getMemberId(token), OWNER);
+
+    return ResponseEntity.ok("회원이 삭제되었습니다.");
+  }
+
+  @Operation(
+      summary = "관리자 정보 수정",
+      tags = {"회원 정보 관리"}
+  )
+  @PutMapping("/admin/update")
+  @PreAuthorize("hasAuthority('ADMIN')")
+  public ResponseEntity<AdminDto> updateAdmin(
+      @RequestHeader(name = "Authorization") String token,
+      @RequestBody AdminUpdateForm signUpForm) {
+
+    return ResponseEntity.ok(memberManageApplication.updateAdmin(
+        jwtProvider.getMemberId(token),
+        signUpForm));
+  }
+
+  @Operation(
+      summary = "관리자 삭제",
+      tags = {"회원 정보 관리"}
+  )
+  @DeleteMapping("/admin/delete")
+  @PreAuthorize("hasAuthority('ADMIN')")
+  public ResponseEntity<String> deleteAdmin(
+      @RequestHeader(name = "Authorization") String token) {
+
+    memberManageApplication.deleteAdmin(jwtProvider.getMemberId(token));
+
+    return ResponseEntity.ok("회원이 삭제되었습니다.");
+  }
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Admin.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Admin.java
@@ -9,11 +9,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 @Entity
 @Builder
 @Getter
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Admin extends BaseEntity {
@@ -27,6 +29,8 @@ public class Admin extends BaseEntity {
   private String phone;
   private String name;
 
+  private boolean deleted;
+
   private boolean adminAuthYn;
 
   public static Admin signUpFrom(AdminSignUpForm signUpForm) {
@@ -36,6 +40,7 @@ public class Admin extends BaseEntity {
         .phone(signUpForm.getPhone())
         .name(signUpForm.getName())
         .adminAuthYn(false)
+        .deleted(false)
         .build();
   }
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Customer.java
@@ -34,6 +34,8 @@ public class Customer extends BaseEntity  implements User {
   private int balance;
   private String account;
 
+  private boolean deleted;
+
   private String emailAuthKey;
   private boolean emailAuthYn;
 
@@ -47,6 +49,7 @@ public class Customer extends BaseEntity  implements User {
         .account(signUpForm.getAccount())
         .emailAuthKey(signUpForm.getEmailAuthKey())
         .emailAuthYn(false)
+        .deleted(false)
         .build();
   }
 

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/Owner.java
@@ -33,6 +33,8 @@ public class Owner extends BaseEntity implements User {
   private String name;
   private String account;
 
+  private boolean deleted;
+
   private String emailAuthKey;
   private boolean emailAuthYn;
 
@@ -45,6 +47,7 @@ public class Owner extends BaseEntity implements User {
         .account(signUpForm.getAccount())
         .emailAuthKey(signUpForm.getEmailAuthKey())
         .emailAuthYn(false)
+        .deleted(false)
         .build();
   }
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/entity/User.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/entity/User.java
@@ -10,5 +10,10 @@ public interface User {
   boolean isEmailAuthYn();
   String getEmailAuthKey();
   String getPassword();
+  void setDeleted(boolean deleted);
+  boolean isDeleted();
   void setEmailAuthYn(boolean emailAuthYn);
+  void setPhone(String phone);
+  void setName(String name);
+  void setAccount(String account);
 }

--- a/src/main/java/com/zerobase/SelfWash/member/domain/form/AdminUpdateForm.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/form/AdminUpdateForm.java
@@ -1,0 +1,17 @@
+package com.zerobase.SelfWash.member.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class AdminUpdateForm {
+  private String phone;
+  private String name;
+}

--- a/src/main/java/com/zerobase/SelfWash/member/domain/form/UserUpdateForm.java
+++ b/src/main/java/com/zerobase/SelfWash/member/domain/form/UserUpdateForm.java
@@ -1,0 +1,18 @@
+package com.zerobase.SelfWash.member.domain.form;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserUpdateForm {
+  private String phone;
+  private String name;
+  private String account;
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/manage/AdminManageService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/manage/AdminManageService.java
@@ -1,0 +1,14 @@
+package com.zerobase.SelfWash.member.service.manage;
+
+import com.zerobase.SelfWash.member.domain.dto.AdminDto;
+import com.zerobase.SelfWash.member.domain.form.AdminUpdateForm;
+
+public interface AdminManageService {
+
+  // 관리인 정보 수정
+  AdminDto updateAdmin(Long id, AdminUpdateForm adminUpdateForm);
+
+  // 관리인 계정 삭제
+  void deleteAdmin(Long id);
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/manage/UserManageService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/manage/UserManageService.java
@@ -1,0 +1,44 @@
+package com.zerobase.SelfWash.member.service.manage;
+
+import com.zerobase.SelfWash.member.domain.dto.UserDto;
+import com.zerobase.SelfWash.member.domain.entity.User;
+import com.zerobase.SelfWash.member.domain.form.UserUpdateForm;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import java.util.Optional;
+import java.util.function.Function;
+
+public interface UserManageService {
+
+  boolean support(MemberType memberType);
+
+  UserDto updateUser (Long id, UserUpdateForm form);
+
+  void deleteUser(Long id);
+
+  //User 정보 수정
+  default UserDto updateUserInfo(
+      Long id, UserUpdateForm form,
+      Function<Long, Optional<? extends User>> findById
+  ) {
+    User user = findById.apply(id)
+        .orElseThrow(() -> new RuntimeException("존재하는 회원 정보가 없습니다."));
+
+    user.setPhone(form.getPhone());
+    user.setName(form.getName());
+    user.setAccount(form.getAccount());
+
+    return UserDto.from(user);
+  }
+
+  //User 계정 삭제
+  default void deleteUserInfo(
+      Long id,
+      Function<Long, Optional<? extends User>> findById
+  ) {
+    User user = findById.apply(id)
+        .orElseThrow(() -> new RuntimeException("존재하는 회원 정보가 없습니다."));
+
+    user.setDeleted(true);
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/AdminManageServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/AdminManageServiceImpl.java
@@ -1,0 +1,34 @@
+package com.zerobase.SelfWash.member.service.manage.impl;
+
+import com.zerobase.SelfWash.member.domain.dto.AdminDto;
+import com.zerobase.SelfWash.member.domain.entity.Admin;
+import com.zerobase.SelfWash.member.domain.form.AdminUpdateForm;
+import com.zerobase.SelfWash.member.domain.repository.AdminRepository;
+import com.zerobase.SelfWash.member.service.manage.AdminManageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminManageServiceImpl implements AdminManageService {
+
+  private final AdminRepository adminRepository;
+
+  @Override
+  @Transactional
+  public AdminDto updateAdmin(Long id, AdminUpdateForm adminUpdateForm) {
+    Admin admin = adminRepository.findById(id).orElseThrow(RuntimeException::new);
+    admin.setName(adminUpdateForm.getName());
+    admin.setPhone(adminUpdateForm.getPhone());
+    return AdminDto.from(admin);
+  }
+
+  @Override
+  @Transactional
+  public void deleteAdmin(Long id) {
+    Admin admin = adminRepository.findById(id).orElseThrow(RuntimeException::new);
+    admin.setDeleted(true);
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/CustomerManageServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/CustomerManageServiceImpl.java
@@ -1,0 +1,36 @@
+package com.zerobase.SelfWash.member.service.manage.impl;
+
+import static com.zerobase.SelfWash.member.domain.type.MemberType.CUSTOMER;
+
+import com.zerobase.SelfWash.member.domain.dto.UserDto;
+import com.zerobase.SelfWash.member.domain.form.UserUpdateForm;
+import com.zerobase.SelfWash.member.domain.repository.CustomerRepository;
+import com.zerobase.SelfWash.member.domain.repository.OwnerRepository;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import com.zerobase.SelfWash.member.service.manage.UserManageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerManageServiceImpl implements UserManageService {
+
+  private final CustomerRepository customerRepository;
+
+  @Transactional
+  @Override
+  public UserDto updateUser(Long id, UserUpdateForm form) {
+    return updateUserInfo(id, form, customerRepository::findById);
+  }
+
+  @Transactional
+  public void deleteUser(Long id) {
+    deleteUserInfo(id, customerRepository::findById);
+  }
+
+  @Override
+  public boolean support(MemberType memberType) {
+    return CUSTOMER == memberType;
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/OwnerManageServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/manage/impl/OwnerManageServiceImpl.java
@@ -1,0 +1,37 @@
+package com.zerobase.SelfWash.member.service.manage.impl;
+
+import static com.zerobase.SelfWash.member.domain.type.MemberType.CUSTOMER;
+import static com.zerobase.SelfWash.member.domain.type.MemberType.OWNER;
+
+import com.zerobase.SelfWash.member.domain.dto.UserDto;
+import com.zerobase.SelfWash.member.domain.form.UserUpdateForm;
+import com.zerobase.SelfWash.member.domain.repository.OwnerRepository;
+import com.zerobase.SelfWash.member.domain.type.MemberType;
+import com.zerobase.SelfWash.member.service.manage.UserManageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerManageServiceImpl implements UserManageService {
+
+  private final OwnerRepository ownerRepository;
+
+  @Transactional
+  @Override
+  public UserDto updateUser(Long id, UserUpdateForm form) {
+    return updateUserInfo(id, form, ownerRepository::findById);
+  }
+
+  @Transactional
+  public void deleteUser(Long id) {
+    deleteUserInfo(id, ownerRepository::findById);
+  }
+
+  @Override
+  public boolean support(MemberType memberType) {
+    return OWNER == memberType;
+
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/member/service/signin/UserSignInService.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/signin/UserSignInService.java
@@ -29,6 +29,10 @@ public interface UserSignInService extends UserDetailsService {
       throw new RuntimeException("비밀번호가 일치하지 않습니다.");
     }
 
+    if (user.isDeleted()) {
+      throw new RuntimeException("삭제된 회원입니다.");
+    }
+
     return UserDto.from(user);
   };
 }

--- a/src/main/java/com/zerobase/SelfWash/member/service/signin/impl/AdminSignInServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/member/service/signin/impl/AdminSignInServiceImpl.java
@@ -2,12 +2,10 @@ package com.zerobase.SelfWash.member.service.signin.impl;
 
 import static com.zerobase.SelfWash.member.domain.type.MemberType.ADMIN;
 
-import com.zerobase.SelfWash.config.security.JwtProvider;
 import com.zerobase.SelfWash.member.domain.dto.AdminDto;
 import com.zerobase.SelfWash.member.domain.entity.Admin;
 import com.zerobase.SelfWash.member.domain.form.SignInForm;
 import com.zerobase.SelfWash.member.domain.repository.AdminRepository;
-import com.zerobase.SelfWash.member.domain.type.MemberType;
 import com.zerobase.SelfWash.member.service.signin.AdminSignInService;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +35,10 @@ public class AdminSignInServiceImpl implements AdminSignInService {
 
     if (!BCrypt.checkpw(signInForm.getPassword(), admin.getPassword())) {
       throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+    }
+
+    if (admin.isDeleted()) {
+      throw new RuntimeException("삭제된 회원입니다.");
     }
 
     return AdminDto.from(admin);

--- a/src/main/scratch/memberManage.http
+++ b/src/main/scratch/memberManage.http
@@ -1,0 +1,22 @@
+### 고객 회원정보 수정
+PUT http://localhost:8080/manage/customer/update
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJNM0lYSW5MaDZwTG1YU2t4WFNGczNlUE1KbDFHSUNBYllOdlFlVUtzMGJZPSIsImp0aSI6IkNtWUR2NU1LNVlVeWlrOEtHTkR3b3c9PSIsInJvbGVzIjoiT1dORVIiLCJpYXQiOjE3NDEzMTIyNTcsImV4cCI6MTc0MTM5ODY1N30.eVRc7qG3UTRz_0tozUPQyKkoy7IzL3pfBmEaJ-3B4SY
+
+{
+  "phone": "010-5000-2223",
+  "name": "mike2",
+  "account": "1111-1111-1111-1111"
+}
+
+###점주 회원정보 수정
+PUT http://localhost:8080/manage/owner/update
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJNM0lYSW5MaDZwTG1YU2t4WFNGczNlUE1KbDFHSUNBYllOdlFlVUtzMGJZPSIsImp0aSI6IkNtWUR2NU1LNVlVeWlrOEtHTkR3b3c9PSIsInJvbGVzIjoiT1dORVIiLCJpYXQiOjE3NDEzMTIyNTcsImV4cCI6MTc0MTM5ODY1N30.eVRc7qG3UTRz_0tozUPQyKkoy7IzL3pfBmEaJ-3B4SY
+
+{
+"phone": "010-5000-2223",
+"name": "mike2",
+"account": "1111-1111-1111-1111"
+}
+


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 멤버 관리 기능 (정보 수정, 삭제) 없었음
- swagger-ui 없었음
**TO-BE**
- 멤버 관리 기능 (정보 수정, 삭제) 추가
- UserUpdateForm, AdminUpdateForm을 통해 정보 수정 요청
- 토큰을 통해 권한 인증 후 올바른 권한을 지닌 경우에만 해당 요청 가능
- 멤버 삭제는 데이터 베이스에서 완전히 삭제되는 것이 아니라 상태를 변경 (엔티티의 boolean deleted 를 true로 변경)
- 편리한 API 테스트를 위해 OpenApi 라이브러리 추가하여 swagger-ui 구현
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 