### PR TITLE
feat: 점주 문의 신청 기능(CRUD) 추가, 관리자 점주 문의 관리 기능(문의처리완료) 추가

### DIFF
--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/controller/AdministerInquiryController.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/controller/AdministerInquiryController.java
@@ -1,0 +1,45 @@
+package com.zerobase.SelfWash.owner_inquiry.controller;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.dto.OwnerInquiryDto;
+import com.zerobase.SelfWash.owner_inquiry.service.AdminInquiryService;
+import com.zerobase.SelfWash.owner_inquiry.service.OwnerInquiryService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/inquiry/admin")
+@RequiredArgsConstructor
+//TODO 관리자 권한 실행
+public class AdministerInquiryController {
+
+  private final AdminInquiryService adminInquiryService;
+  private final OwnerInquiryService ownerInquiryService;
+
+  @Operation(
+      summary = "문의 처리",
+      tags = {"점주 문의 관리"}
+  )
+  @PutMapping
+  public ResponseEntity<String> resolveInquiry(@RequestParam Long inquiryId) {
+    adminInquiryService.resolveInquiry(inquiryId);
+    return ResponseEntity.ok("문의 처리 완료되었습니다.");
+  }
+
+  @Operation(
+      summary = "점주 문의 내역 조회",
+      tags = {"점주 문의 관리"}
+  )
+  @GetMapping
+  public ResponseEntity<List<OwnerInquiryDto>> searchOwnerInquiry(@RequestParam Long ownerId) {
+
+    return ResponseEntity.ok(ownerInquiryService.searchOwnerInquiry(ownerId));
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/controller/OwnerInquiryController.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/controller/OwnerInquiryController.java
@@ -1,0 +1,89 @@
+package com.zerobase.SelfWash.owner_inquiry.controller;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.dto.OwnerInquiryDto;
+import com.zerobase.SelfWash.owner_inquiry.domain.form.OwnerInquiryForm;
+import com.zerobase.SelfWash.owner_inquiry.service.OwnerInquiryService;
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/inquiry")
+@RequiredArgsConstructor
+public class OwnerInquiryController {
+
+  private final OwnerInquiryService ownerInquiryService;
+
+  //TODO 추후에 @RequestParam Long ownerId -> @AuthenticationPrincipal로 변경
+
+
+  @Operation(
+      summary = "문의 신청",
+      tags = {"점주 문의"}
+  )
+  @PostMapping
+  public ResponseEntity<OwnerInquiryDto> create(
+      @RequestParam Long ownerId,
+      @RequestBody OwnerInquiryForm form) {
+
+    return ResponseEntity.ok(ownerInquiryService.create(ownerId, form));
+  }
+
+  @Operation(
+      summary = "문의 내용 수정",
+      tags = {"점주 문의"}
+  )
+  @PutMapping
+  public ResponseEntity<String> modify(
+      @RequestParam Long inquiryId,
+      @RequestBody OwnerInquiryForm form) {
+
+    ownerInquiryService.modify(inquiryId, form);
+    return ResponseEntity.ok("문의 내용이 수정되었습니다.");
+  }
+
+  @Operation(
+      summary = "문의 삭제",
+      tags = {"점주 문의"}
+  )
+  @DeleteMapping
+  public ResponseEntity<String> remove(
+      @RequestParam Long inquiryId
+  ) {
+    ownerInquiryService.remove(inquiryId);
+    return ResponseEntity.ok("문의 내용이 삭제되었습니다.");
+  }
+
+  @Operation(
+      summary = "문의 내용 조회",
+      tags = {"점주 문의"}
+  )
+  @GetMapping
+  public ResponseEntity<OwnerInquiryDto> search(
+      @RequestParam Long inquiryId
+  ) {
+    return ResponseEntity.ok(ownerInquiryService.search(inquiryId));
+  }
+
+  @Operation(
+      summary = "문의 내역 조회",
+      tags = {"점주 문의"}
+  )
+  @GetMapping("/ownerinquiry")
+  public ResponseEntity<List<OwnerInquiryDto>> searchOwnerInquiry(
+      @RequestParam Long OwnerId
+  )
+  {
+    return ResponseEntity.ok(ownerInquiryService.searchOwnerInquiry(OwnerId));
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/dto/OwnerInquiryDto.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/dto/OwnerInquiryDto.java
@@ -1,0 +1,40 @@
+package com.zerobase.SelfWash.owner_inquiry.domain.dto;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.entity.OwnerInquiry;
+import com.zerobase.SelfWash.owner_inquiry.domain.form.OwnerInquiryForm;
+import com.zerobase.SelfWash.owner_inquiry.domain.type.InquiryType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerInquiryDto {
+
+  private long inquiryId;
+
+  private Long ownerId;
+  private InquiryType inquiryType;
+  private String contents;
+  private boolean resolved;
+
+  public static OwnerInquiryDto from(OwnerInquiry inquiry) {
+    return OwnerInquiryDto.builder()
+        .inquiryId(inquiry.getId())
+        .ownerId(inquiry.getOwnerId())
+        .inquiryType(inquiry.getInquiryType())
+        .contents(inquiry.getContents())
+        .resolved(inquiry.isResolved())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/entity/OwnerInquiry.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/entity/OwnerInquiry.java
@@ -1,0 +1,46 @@
+package com.zerobase.SelfWash.owner_inquiry.domain.entity;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.form.OwnerInquiryForm;
+import com.zerobase.SelfWash.owner_inquiry.domain.type.InquiryType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Builder
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerInquiry {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private Long ownerId;
+  private InquiryType inquiryType;
+  private String contents;
+  private boolean resolved;
+
+  public static OwnerInquiry from(Long ownerId, OwnerInquiryForm form) {
+    return OwnerInquiry.builder()
+        .ownerId(ownerId)
+        .inquiryType(form.getInquiryType())
+        .contents(form.getContents())
+        .resolved(false)
+        .build();
+  }
+
+  public void modify(OwnerInquiryForm form) {
+    this.setInquiryType(form.getInquiryType());
+    this.setContents(form.getContents());
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/form/OwnerInquiryForm.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/form/OwnerInquiryForm.java
@@ -1,0 +1,20 @@
+package com.zerobase.SelfWash.owner_inquiry.domain.form;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.type.InquiryType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Builder
+@Setter
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class OwnerInquiryForm {
+
+  private InquiryType inquiryType;
+  private String contents;
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/repository/OwnerInquiryRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/repository/OwnerInquiryRepository.java
@@ -1,0 +1,12 @@
+package com.zerobase.SelfWash.owner_inquiry.domain.repository;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.entity.OwnerInquiry;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OwnerInquiryRepository extends JpaRepository<OwnerInquiry, Long> {
+  List<OwnerInquiry> findAllByOwnerId(Long ownerId);
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/type/InquiryType.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/domain/type/InquiryType.java
@@ -1,0 +1,8 @@
+package com.zerobase.SelfWash.owner_inquiry.domain.type;
+
+public enum InquiryType {
+  FOUNDATION, //창업 문의
+  REPAIR, // 수리 문의
+  CLOSURE, // 폐점 문의
+  ETC // 기타
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/AdminInquiryService.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/AdminInquiryService.java
@@ -1,0 +1,10 @@
+package com.zerobase.SelfWash.owner_inquiry.service;
+
+public interface AdminInquiryService {
+
+  /**
+   * 문의 처리 완료
+   */
+  void resolveInquiry(Long inquiryId);
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/OwnerInquiryService.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/OwnerInquiryService.java
@@ -1,0 +1,34 @@
+package com.zerobase.SelfWash.owner_inquiry.service;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.dto.OwnerInquiryDto;
+import com.zerobase.SelfWash.owner_inquiry.domain.form.OwnerInquiryForm;
+import java.util.List;
+
+public interface OwnerInquiryService {
+
+  /**
+   * 점주 문의 생성
+   */
+  OwnerInquiryDto create(Long ownerId, OwnerInquiryForm form);
+
+  /**
+   * 문의 내용 수정 (답변 미완료 상태에서만 수정 가능)
+   */
+  void modify(Long inquiryId, OwnerInquiryForm form);
+
+  /**
+   * 문의 삭제 (바로 데이터 삭제됨)
+   */
+  void remove(Long inquiryId);
+
+  /**
+   *  문의 내용 조회
+   */
+  OwnerInquiryDto search(Long inquiryId);
+
+  /**
+   * (로그인 한) 점주의 문의 내용 전체 조회
+   */
+  List<OwnerInquiryDto> searchOwnerInquiry(Long ownerId);
+
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/impl/AdminInquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/impl/AdminInquiryServiceImpl.java
@@ -1,0 +1,28 @@
+package com.zerobase.SelfWash.owner_inquiry.service.impl;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.entity.OwnerInquiry;
+import com.zerobase.SelfWash.owner_inquiry.domain.repository.OwnerInquiryRepository;
+import com.zerobase.SelfWash.owner_inquiry.service.AdminInquiryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminInquiryServiceImpl implements AdminInquiryService {
+
+  private final OwnerInquiryRepository ownerInquiryRepository;
+
+  @Override
+  @Transactional
+  public void resolveInquiry(Long inquiryId) {
+    OwnerInquiry inquiry = ownerInquiryRepository.findById(inquiryId)
+        .orElseThrow(() -> new RuntimeException("해당하는 문의 내용이 없습니다."));
+
+    if (inquiry.isResolved()) {
+      throw new RuntimeException("이미 처리된 문의입니다.");
+    }
+
+    inquiry.setResolved(true);
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/impl/OwnerInquiryServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/owner_inquiry/service/impl/OwnerInquiryServiceImpl.java
@@ -1,0 +1,68 @@
+package com.zerobase.SelfWash.owner_inquiry.service.impl;
+
+import com.zerobase.SelfWash.owner_inquiry.domain.dto.OwnerInquiryDto;
+import com.zerobase.SelfWash.owner_inquiry.domain.entity.OwnerInquiry;
+import com.zerobase.SelfWash.owner_inquiry.domain.form.OwnerInquiryForm;
+import com.zerobase.SelfWash.owner_inquiry.domain.repository.OwnerInquiryRepository;
+import com.zerobase.SelfWash.owner_inquiry.service.OwnerInquiryService;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnerInquiryServiceImpl implements OwnerInquiryService {
+
+  private final OwnerInquiryRepository ownerInquiryRepository;
+
+  @Override
+  @Transactional
+  public OwnerInquiryDto create(Long ownerId ,OwnerInquiryForm form) {
+
+    return OwnerInquiryDto.from(ownerInquiryRepository.save(OwnerInquiry.from(ownerId, form)));
+  }
+
+  @Override
+  @Transactional
+  public void modify(Long inquiryId, OwnerInquiryForm form) {
+    OwnerInquiry inquiry = ownerInquiryRepository.findById(inquiryId)
+        .orElseThrow(() -> new RuntimeException("해당하는 문의 내용이 없습니다."));
+
+    if (inquiry.isResolved()) {
+      throw new RuntimeException("이미 처리 완료된 문의는 수정할 수 없습니다.");
+    }
+
+    inquiry.modify(form);
+  }
+
+  @Override
+  @Transactional
+  public void remove(Long inquiryId) {
+    OwnerInquiry inquiry = ownerInquiryRepository.findById(inquiryId)
+        .orElseThrow(() -> new RuntimeException("해당하는 문의 내용이 없습니다."));
+
+    ownerInquiryRepository.delete(inquiry);
+  }
+
+  @Override
+  @Transactional
+  public OwnerInquiryDto search(Long inquiryId) {
+
+    return OwnerInquiryDto.from(ownerInquiryRepository.findById(inquiryId)
+        .orElseThrow(() -> new RuntimeException("해당하는 문의 내용이 없습니다.")));
+  }
+
+  @Override
+  @Transactional
+  public List<OwnerInquiryDto> searchOwnerInquiry(Long ownerId) {
+    List<OwnerInquiry> ownerInquiryList = ownerInquiryRepository.findAllByOwnerId(ownerId);
+
+    if (ownerInquiryList.isEmpty()) {
+      throw new RuntimeException("요청 문의사항이 존재하지 않습니다.");
+    }
+
+    return ownerInquiryList.stream().map(OwnerInquiryDto::from).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 점주 문의 신청 기능 없었음
- 관리자가 점주 문의 관리하는 기능 없었음

**TO-BE**
- 점주 문의 엔티티 생성
- 점주 문의 신청 기능
문의 유형, 내용 작성 후 문의 신청
기본적인 문의 내용 조회, 수정, 삭제 기능 구현 
(이미 처리완료된 문의 경우 수정 불가능)
점주 자신이 문의한 내역 전체 조회 가능
- 관리자 점주 문의 처리 기능 
문의 내용 처리시 관리자가 문의 내용 처리 완료로 변경 
특정 점주의 문의 내역 전체 조회 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 