### PR TITLE
feat: 기계 사용, 예약 기능 추가, 스케쥴러를 통한 기계상태 자동 변경

### DIFF
--- a/src/main/java/com/zerobase/SelfWash/SelfWashApplication.java
+++ b/src/main/java/com/zerobase/SelfWash/SelfWashApplication.java
@@ -3,9 +3,11 @@ package com.zerobase.SelfWash;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class SelfWashApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/zerobase/SelfWash/administer_store/domain/repository/MachineRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/administer_store/domain/repository/MachineRepository.java
@@ -1,10 +1,17 @@
 package com.zerobase.SelfWash.administer_store.domain.repository;
 
 import com.zerobase.SelfWash.administer_store.domain.entity.Machine;
+import java.time.LocalDateTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MachineRepository extends JpaRepository<Machine, Long> {
 
+  @Query("SELECT m FROM Machine m WHERE (:time IS NOT NULL AND m.endTime <= :time)")
+  Page<Machine> findMachinesEndingBefore(@Param("time")  LocalDateTime endTime, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/SelfWash/administer_store/domain/type/UsageStatus.java
+++ b/src/main/java/com/zerobase/SelfWash/administer_store/domain/type/UsageStatus.java
@@ -1,5 +1,5 @@
 package com.zerobase.SelfWash.administer_store.domain.type;
 
 public enum UsageStatus {
-  USING, BOOKED, USABLE, UNUSABLE
+  USING, RESERVED, USABLE, UNUSABLE
 }

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/controller/MachineReserveController.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/controller/MachineReserveController.java
@@ -1,0 +1,44 @@
+package com.zerobase.SelfWash.customer.use_machine.controller;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineReserveDto;
+import com.zerobase.SelfWash.customer.use_machine.service.MachineReserveService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reserve")
+public class MachineReserveController {
+
+  private final MachineReserveService machineReserveService;
+
+  @Operation(
+      summary = "기계 예약",
+      tags = {"기계 예약"}
+  )
+  @PostMapping
+  public ResponseEntity<MachineReserveDto> reserve(
+      @RequestParam Long customerId,
+      @RequestParam Long machineId) {
+
+    return ResponseEntity.ok(machineReserveService.reserve(customerId, machineId));
+  }
+
+  @Operation(
+      summary = "기계 예약 취소",
+      tags = {"기계 예약"}
+  )
+  @DeleteMapping
+  public ResponseEntity<String> reserveCancel(
+      @RequestParam Long customerId,
+      @RequestParam Long machineId) {
+    machineReserveService.reserveCancel(customerId, machineId);
+    return ResponseEntity.ok("예약이 취소되었습니다.");
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/controller/MachineUseController.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/controller/MachineUseController.java
@@ -1,0 +1,48 @@
+package com.zerobase.SelfWash.customer.use_machine.controller;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineUseDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+import com.zerobase.SelfWash.customer.use_machine.service.MachineUseService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import jakarta.annotation.Resource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/use")
+@RequiredArgsConstructor
+public class MachineUseController {
+
+  private final MachineUseService machineUseService;
+
+  @Operation(
+      summary = "기계 사용 시작",
+      tags = {"기계 사용"}
+  )
+  @PostMapping
+  public ResponseEntity<MachineUseDto> use(
+      @RequestParam Long customerId,
+      @RequestBody MachineUseForm form) {
+    return ResponseEntity.ok(machineUseService.use(customerId, form));
+  }
+
+  @Operation(
+      summary = "기계 사용 종료",
+      tags = {"기계 사용"}
+  )
+  @PutMapping
+  public ResponseEntity<String> finish(
+      @RequestParam Long machineId
+  ) {
+    machineUseService.finish(machineId);
+    return ResponseEntity.ok("기계 사용이 종료되었습니다.");
+  }
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/dto/MachineReserveDto.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/dto/MachineReserveDto.java
@@ -1,0 +1,40 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.dto;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineReserve;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MachineReserveDto {
+
+  private long reserveId;
+  private long machineId;
+  private long customerId;
+
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+
+
+  public static MachineReserveDto from(MachineReserve machineReserve) {
+    return MachineReserveDto.builder()
+        .reserveId(machineReserve.getId())
+        .machineId(machineReserve.getMachineId())
+        .customerId(machineReserve.getCustomerId())
+        .startTime(machineReserve.getStartTime())
+        .endTime(machineReserve.getEndTime())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/dto/MachineUseDto.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/dto/MachineUseDto.java
@@ -1,0 +1,34 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.dto;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineUse;
+import com.zerobase.SelfWash.customer.use_machine.domain.type.WashingCourse;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MachineUseDto {
+  private long useId;
+  private long machineId;
+  private WashingCourse washingCourse;
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+
+  public static MachineUseDto from(MachineUse machineUse) {
+   return  MachineUseDto.builder()
+        .useId(machineUse.getId())
+        .machineId(machineUse.getMachineId())
+        .washingCourse(machineUse.getWashingCourse())
+        .startTime(machineUse.getStartTime())
+        .endTime(machineUse.getEndTime())
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/entity/MachineReserve.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/entity/MachineReserve.java
@@ -1,0 +1,45 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.entity;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+import com.zerobase.SelfWash.customer.use_machine.domain.type.WashingCourse;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MachineReserve {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private long machineId;
+  private long customerId;
+
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+
+
+  public static MachineReserve from(Long customerId, Long machineId) {
+    return MachineReserve.builder()
+        .machineId(machineId)
+        .customerId(customerId)
+        .startTime(LocalDateTime.now())
+        .endTime(LocalDateTime.now().plusMinutes(15))
+        .build();
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/entity/MachineUse.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/entity/MachineUse.java
@@ -1,0 +1,61 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.entity;
+
+import com.zerobase.SelfWash.administer_store.domain.form.MachineForm;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+import com.zerobase.SelfWash.customer.use_machine.domain.type.WashingCourse;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MachineUse {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+  private long machineId;
+  private long customerId;
+
+  @Enumerated(EnumType.STRING)
+  private WashingCourse washingCourse;
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+
+  public static MachineUse from(long customerId, MachineUseForm form) {
+    return MachineUse.builder()
+        .machineId(form.getMachineId())
+        .customerId(customerId)
+        .washingCourse(form.getWashingCourse())
+        .startTime(LocalDateTime.now())
+        .endTime(usingTime(form.getWashingCourse()))
+        .build();
+  }
+
+  private static LocalDateTime usingTime(WashingCourse washingCourse) {
+    if (washingCourse == WashingCourse.NORMAL) {
+      return LocalDateTime.now().plusMinutes(30);
+    } else if (washingCourse == WashingCourse.FAST) {
+      return LocalDateTime.now().plusMinutes(20);
+    } else if (washingCourse == WashingCourse.BEDDING) {
+      return LocalDateTime.now().plusMinutes(60);
+    } else if (washingCourse == WashingCourse.WOOL) {
+      return LocalDateTime.now().plusMinutes(40);
+    }
+    throw new RuntimeException("코스 설정이 되어있지 않습니다.");
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/form/MachineUseForm.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/form/MachineUseForm.java
@@ -1,0 +1,18 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.form;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.type.WashingCourse;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MachineUseForm {
+  private long machineId;
+  private WashingCourse washingCourse;
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/repository/MachineReserveRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/repository/MachineReserveRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.repository;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineReserve;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MachineReserveRepository extends JpaRepository<MachineReserve, Long> {
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/repository/MachineUseRepository.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/repository/MachineUseRepository.java
@@ -1,0 +1,10 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.repository;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineUse;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MachineUseRepository extends JpaRepository<MachineUse, Long> {
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/type/WashingCourse.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/domain/type/WashingCourse.java
@@ -1,0 +1,5 @@
+package com.zerobase.SelfWash.customer.use_machine.domain.type;
+
+public enum WashingCourse {
+  NORMAL, FAST, WOOL, BEDDING
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineReserveService.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineReserveService.java
@@ -1,0 +1,25 @@
+package com.zerobase.SelfWash.customer.use_machine.service;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineReserveDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineUseDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+
+public interface MachineReserveService {
+
+  /**
+   * 기계 사용 예약
+   */
+  MachineReserveDto reserve(Long customerId, Long machineId);
+
+  /**
+   * 기계 사용 예약 취소
+   */
+  void reserveCancel(Long customerId, Long machineId);
+
+
+
+
+
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineSchedulerService.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineSchedulerService.java
@@ -1,0 +1,65 @@
+package com.zerobase.SelfWash.customer.use_machine.service;
+
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.USABLE;
+
+import com.zerobase.SelfWash.administer_store.domain.entity.Machine;
+import com.zerobase.SelfWash.administer_store.domain.repository.MachineRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MachineSchedulerService {
+
+  private final MachineRepository machineRepository;
+
+  @Scheduled(cron = "0 * * * * *")
+  public void updateMachineStatus() {
+    LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES);
+    int pageSize = 100;
+    int pageNumber = 0;
+    Page<Machine> machinePage;
+
+    log.info("기계 사용현황 업데이트 스케줄러 시작: {}", LocalDateTime.now());
+    try {
+      do {
+
+        //페이지 단위로 데이터 조회
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        machinePage = machineRepository.findMachinesEndingBefore(now, pageable);
+
+        log.info("사용가능 상태로 변경된 기계 수 : {}", machinePage.getNumberOfElements());
+
+        //현재 페이지 처리
+        changeMachineStatus(machinePage);
+        //다음 페이지로 이동
+        pageNumber++;
+
+      } while (machinePage.hasNext());
+    } catch (Exception e) {
+      log.error("기계 사용현황 업데이트 중 오류 발생 : {}",e.getMessage());
+    } finally {
+      log.info("기계 사용현황 업데이트 스케줄러 종료: {}", LocalDateTime.now());
+    }
+
+  }
+
+  private void changeMachineStatus(Page<Machine> machinePage) {
+    for (Machine machine : machinePage) {
+      machine.setEndTime(null);
+      machine.setCustomerId(null);
+      machine.setUsageStatus(USABLE);
+      log.info("상태 업데이트 기계 ID  : {}", machine.getId());
+    }
+    machineRepository.saveAll(machinePage.getContent());
+  }
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineUseService.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/MachineUseService.java
@@ -1,0 +1,24 @@
+package com.zerobase.SelfWash.customer.use_machine.service;
+
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineReserveDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineUseDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+
+public interface MachineUseService {
+
+  /**
+   * 기계 사용
+   */
+  MachineUseDto use(Long customerId, MachineUseForm form);
+
+  /**
+   * 기계사용 종료
+   */
+  void finish(Long machineId);
+
+
+
+
+
+
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/impl/MachineReserveServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/impl/MachineReserveServiceImpl.java
@@ -1,0 +1,80 @@
+package com.zerobase.SelfWash.customer.use_machine.service.impl;
+
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.RESERVED;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.UNUSABLE;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.USABLE;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.USING;
+
+import com.zerobase.SelfWash.administer_store.domain.entity.Machine;
+import com.zerobase.SelfWash.administer_store.domain.repository.MachineRepository;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineReserveDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineUseDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineReserve;
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineUse;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+import com.zerobase.SelfWash.customer.use_machine.domain.repository.MachineReserveRepository;
+import com.zerobase.SelfWash.customer.use_machine.domain.repository.MachineUseRepository;
+import com.zerobase.SelfWash.customer.use_machine.service.MachineReserveService;
+import com.zerobase.SelfWash.customer.use_machine.service.MachineUseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MachineReserveServiceImpl implements MachineReserveService {
+
+  private final MachineReserveRepository machineReserveRepository;
+  private final MachineRepository machineRepository;
+
+  @Override
+  @Transactional
+  public MachineReserveDto reserve(Long customerId, Long machineId) {
+    Machine machine = machineRepository.findById(machineId)
+        .orElseThrow(() -> new RuntimeException("해당하는 기계 정보가 없습니다."));
+
+    if (!machine.getStore().isOpened()) {
+      throw new RuntimeException("운영 중인 매장이 아닙니다.");
+    }
+
+    if (machine.getUsageStatus() != USABLE) {
+      throw new RuntimeException("예약 불가능한 기계입니다.");
+    }
+
+    MachineReserve machineReserve = machineReserveRepository.save(MachineReserve.from(customerId, machineId));
+
+    // 기계DB 예약 정보 업데이트
+    machine.setEndTime(machineReserve.getEndTime());
+    machine.setCustomerId(customerId);
+    machine.setUsageStatus(RESERVED);
+
+    return MachineReserveDto.from(machineReserve);
+  }
+
+  @Override
+  @Transactional
+  public void reserveCancel(Long customerId, Long reserveId) {
+    MachineReserve machineReserve = machineReserveRepository.findById(reserveId)
+        .orElseThrow(() -> new RuntimeException("해당하는 예약 정보가 없습니다."));
+
+    if (machineReserve.getCustomerId() != customerId) {
+      throw new RuntimeException("예약자가 아닙니다.");
+    }
+
+    Machine machine = machineRepository.findById(machineReserve.getMachineId())
+        .orElseThrow(() -> new RuntimeException("해당하는 기계 정보가 없습니다."));
+
+    if (machine.getUsageStatus() != RESERVED) {
+      throw new RuntimeException("예약상태가 아닙니다.");
+    }
+
+    // 기계DB 예약 가능 상태로 업데이트
+    machine.setEndTime(null);
+    machine.setCustomerId(null);
+    machine.setUsageStatus(USABLE);
+
+    machineReserveRepository.delete(machineReserve);
+  }
+}

--- a/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/impl/MachineUseServiceImpl.java
+++ b/src/main/java/com/zerobase/SelfWash/customer/use_machine/service/impl/MachineUseServiceImpl.java
@@ -1,0 +1,94 @@
+package com.zerobase.SelfWash.customer.use_machine.service.impl;
+
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.RESERVED;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.UNUSABLE;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.USABLE;
+import static com.zerobase.SelfWash.administer_store.domain.type.UsageStatus.USING;
+
+import com.zerobase.SelfWash.administer_store.domain.entity.Machine;
+import com.zerobase.SelfWash.administer_store.domain.repository.MachineRepository;
+import com.zerobase.SelfWash.administer_store.domain.type.UsageStatus;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineReserveDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.dto.MachineUseDto;
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineReserve;
+import com.zerobase.SelfWash.customer.use_machine.domain.entity.MachineUse;
+import com.zerobase.SelfWash.customer.use_machine.domain.form.MachineUseForm;
+import com.zerobase.SelfWash.customer.use_machine.domain.repository.MachineReserveRepository;
+import com.zerobase.SelfWash.customer.use_machine.domain.repository.MachineUseRepository;
+import com.zerobase.SelfWash.customer.use_machine.service.MachineUseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MachineUseServiceImpl implements MachineUseService {
+
+  private final MachineUseRepository machineUseRepository;
+  private final MachineRepository machineRepository;
+
+  @Override
+  @Transactional
+  public MachineUseDto use(Long customerId, MachineUseForm form) {
+    Machine machine = machineRepository.findById(form.getMachineId())
+        .orElseThrow(() -> new RuntimeException("해당하는 기계 정보가 없습니다."));
+
+    if (!usableMachine(customerId, machine)) {
+      throw new RuntimeException("사용 불가능한 기계입니다.");
+    }
+
+    MachineUse machineUse = machineUseRepository.save(MachineUse.from(customerId, form));
+
+    // 기계DB 사용정보 업데이트
+    machine.setEndTime(machineUse.getEndTime());
+    machine.setUsageStatus(USING);
+
+    return MachineUseDto.from(machineUse);
+  }
+
+  @Override
+  @Transactional
+  public void finish(Long machineId) {
+    Machine machine = machineRepository.findById(machineId)
+        .orElseThrow(() -> new RuntimeException("해당하는 기계 정보가 없습니다."));
+
+    // 기계DB 사용 가능 상태로 업데이트
+    machine.setEndTime(null);
+    machine.setUsageStatus(USABLE);
+  }
+
+  private boolean usableMachine(Long customerId, Machine machine) {
+    //운영하지 않는 매장인 경우
+    if (!machine.getStore().isOpened()) {
+      log.warn("운영 중단 매장 : {}", machine.getStore().getId());
+      return false;
+    }
+
+    // 사용 불가 상태인 경우
+    if (machine.getUsageStatus() == UNUSABLE || machine.getUsageStatus() == USING) {
+      log.warn("현재 사용 불가 기계 : {}", machine.getId());
+      return false;
+    }
+
+    // 예약된 상태인 경우
+    if (machine.getUsageStatus() == RESERVED) {
+
+      Long bookedCustomerId = machine.getCustomerId();
+
+      // 예약자 정보가 없는 경우 (비정상 처리)
+      if (bookedCustomerId == null) {
+        log.warn("예약 정보 손상 : {}", customerId);
+        return false;
+      }
+
+      // 예약자가 아닌 경우
+      if (!bookedCustomerId.equals(customerId)) {
+        log.warn("예약자 정보 불일치 : {}", customerId);
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
### 변경사항
**AS-IS**
- 기계 사용, 예약 기능 없었음
**TO-BE**
- `MachineUseController`
  - `POST "/use"` api를 통해 고객Id, `MachineUseForm` 데이터를 입력받아 기계 사용.
    - `MachineUseForm` 내 `machineId` 를 통해 해당 기계 `UseStatus` 값을 `USING`으로 변경
    - 이 때, 만약 이미 사용중`(USING)`이거나 사용불가 `(UNUSABLE)` 일 경우 예외 발생
    -  예약중 `(RESERVED)` 인 경우, `Machine` 값의 고객 ID 와 입력받은 고객 ID 와 일치시에만 사용 가능
    - `USING` 상태 변경 시 사용완료시간 데이터를 `Machine` 에 삽입 
  - `PUT "/use"` api 를 통해 기계 ID 입력 받아 기계 사용 종료
    - 기계 상태를 사용가능 `(USABLE)` 으로 변경
    - 이 때, 사용완료시간 값을 `null`로 변경
- `MachineReserveController`
  - `POST "/reserve"` api를 통해 고객 ID와 기계 ID를 입력받아 기계 예약
    - 해당 기계의 `UseStatus` 값을 `RESERVED` 로 변경
    - 이 때, 마찬가지로 사용중이거나 사용불가 혹은 예약 중인 경우 예약 불가
    - `RESERVED` 상태 변경 시 사용완료시간 데이터와 예약 고객 ID를 `Machine` 에 삽입 
  - `DELETE "/reserve"` api를 통해 고객 ID와 기계 ID를 입력받아 기계 예약취소
    - 해당 기계가 `RESERVED` 상태이고 입력받은 고객ID와 `Machine`에 있는 고객ID와 일치하는 경우에만 예약 취소 가능
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [X] API 테스트 